### PR TITLE
fix: pass context values to handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,8 @@ export function connectWorkersAdapter<Env = unknown, CfHostMetadata = unknown>(
     const handler = paths.get(new URL(request.url).pathname)
     if (!handler) return options.fallback ? options.fallback(request, env, context) : notFoundResponse
 
-    const universalRequest: UniversalServerRequest = requestToUniversalRequest(request)
+    const contextValues = options.contextValues?.(request, env, context)
+    const universalRequest: UniversalServerRequest = requestToUniversalRequest(request, contextValues)
     const universalResponse = await handler(universalRequest)
 
     return universalResponseToResponse(universalResponse)
@@ -78,7 +79,7 @@ export function connectWorkersAdapter<Env = unknown, CfHostMetadata = unknown>(
 
 // Utils **********************************************************************
 
-function requestToUniversalRequest(request: Request): UniversalServerRequest {
+function requestToUniversalRequest(request: Request, contextValues?: ContextValues): UniversalServerRequest {
   const httpVersion = request.cf?.httpProtocol === 'HTTP/2' ? '2.0' : '1.1'
   return {
     httpVersion: httpVersion,
@@ -87,6 +88,7 @@ function requestToUniversalRequest(request: Request): UniversalServerRequest {
     header: request.headers,
     body: request.body,
     signal: request.signal,
+    contextValues,
   }
 }
 


### PR DESCRIPTION
Hey Jacob 👋  Funny coincidence when I saw this package was maintained by Depot.

Cool stuff. I ran into it while playing with ConnectRPC and CloudFlare. I have a minor issue though, I'm trying to pass an R2 bucket to my worker, but context values is never called. I checked upstream library and it seems that it should be passed to the UniversalRequest. This patch fixes it for me - please have a look yourself.

For reference, I'm running on these (peer) dependencies:

```
    "@cloudflare/vitest-pool-workers": "^0.5.2",
    "@cloudflare/workers-types": "4.20241018.0",
    "@bufbuild/buf": "1.45.0",
    "@bufbuild/protobuf": "^1.0.0",
    "@bufbuild/protoc-gen-es": "^1.0.0",
    "@connectrpc/connect": "1.6.1",
    "@connectrpc/protoc-gen-connect-es": "^1.0.0",
    "@depot/connectrpc-workers": "1.1.0"
```

Please let me know if it was intended to be used differently